### PR TITLE
improve wording of process doc

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -108,7 +108,9 @@ in a pairing session. As an issue is started to be worked on, the respective
 team member(s) will self-assign it. Issues are only assigned once work on them
 is actually started. Once an issue is closed via a
 [pull requests](../workflow/) or if it is blocked and cannot progress, the team
-member(s) will self-assign another issue from the iteration backlog.
+member(s) will self-assign another issue from the iteration backlog. We
+recommend [releasing changes](../workflow/) to production (or at least a
+staging) system as they are completed.
 
 If there are any changes requested to the iteration after the planning meeting
 (e.g. due to unforeseeable changes to features or severe bugs popping up in


### PR DESCRIPTION
I updated the wording of the process doc in order to:

* make it better suited for being published on the website
* make it clearer that the goal is to make sure that **everyone** involved in the project is heard
* make it clearer that the project team is not only engineers
* remove some specifics that should go into the workflow doc
* add note on continuous deployment