### PR TITLE
Generalize Process document

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -61,9 +61,9 @@ the feeling of being mere executors of someone else's commands.
 
 The main responsibility of the iteration lead is to consult with the business
 experts (and all other relevant project stakeholders like marketing, designers
-and engineers etc.) and prepare the iteration. Once the iteration started, any
-changes to it that are requested go through the iteration lead for assessment
-(who might consult with other project stakeholders for priorization).
+or engineers) and prepare the iteration. Once the iteration started, any changes
+to it that are requested go through the iteration lead for assessment (who might
+consult with other project stakeholders for priorization).
 
 ### Iteration Preparation
 


### PR DESCRIPTION
This generalizes the process document so it better works for a general process that we can recommend to any team or publish as a book etc. (rather than it just describing something that **we** do).