### PR TITLE
Generalize engineering workflow

### DIFF
--- a/workflow/engineering/README.md
+++ b/workflow/engineering/README.md
@@ -42,16 +42,18 @@ like _"closes #<issue>"_ - most tools will then automatically close the
 referenced issue once the pull request is merged.
 
 As with issues, all discussions around a particular pull request should happen
-on the pull request's page. If discussions happen in person or over online chat,
+on the pull request's page. If discussions happen in person or via online chat,
 a summary should be posted to the pull request so all information and context is
 accessible to everyone interested at any time.
 
 It is perfectly fine to create pull requests early on while implementation is
 still ongoing and they are not yet ready to be reviewed or merged. Doing so is a
 good way to get early feedback and share the status of something with the rest
-of the team. Such pull requests should be marked as _"Work in progress"_ though,
-usually by prefixing their title with `WIP:`. Some tools will even block _"Work
-in progress"_ pull requests from being merged.
+of the team. Such pull requests should be marked as _"Work in progress"_
+though - some tools have dedicated mechanisms for doing so, in others that do
+not offer that, a good technique is prefixing the pull request's title with
+something like `[WIP]`. Some tools will even block _"Work in progress"_ pull
+requests from being merged.
 
 ### Reviews
 
@@ -60,17 +62,22 @@ branch; pull requests that have not been reviewed should usually not get merged.
 In order for a pull request to be ready for review, though, it has to meet some
 pre-requisites:
 
-- the branch has no conflicts with the project's main branch
+- the branch has no conflicts with the target branch
 - the changes in the branch are covered by proper tests and CI is passing
-- the branch is not marked as _"work in progress"_
+- the pull request is not marked as _"work in progress"_
 - the commit history of the pull request has been cleaned up, e.g. WIP commits
   have been squashed, debug commits have been removed etc.
 
 When a pull request is ready for review, its author should actively ask for
 another team member to review - ideally via the tools used in the particular
-project if those support it or over online chat etc. if not. Everyone asked for
-review should reply in a timely manner - even if it's to ask for someone else to
-be chosen if they do not have the time to do a proper review.
+project if those support it or over online chat etc. if not. We generally
+recommend doing rolling reviewer assignment so that not all of the reviews
+depend on one or only a few people and more team members get to review and thus
+understand different parts of the code base. Reviews are a great tool for
+distributing knowledge about the code base among the project team and avoiding
+siloed know-how. Everyone asked for review should reply in a timely manner -
+even if it's to ask for someone else to be chosen if they do not have the time
+to do a proper review.
 
 Once the reviewer approved the changes and CI passes, the pull request can be
 merged by any team member including the pull request's author. If the original
@@ -83,12 +90,12 @@ third person should be brought in to resolve the deadlock.
 #### Review Guidelines
 
 Reviewing and potentially criticizing other people's work is a sensitive issue
-which is why we follow a set of rules when doing so:
+which is why a set of rules should be followed when doing so:
 
 - be polite: you are reviewing another person's work that they put time and
   energy in - don't be dismissive and keep a friendly tone
-- be clear: don't be ambiguous but clearly address issues or aspects that are
-  good about a particular change
+- be clear: don't be ambiguous but clearly address issues or modifications that
+  need to be revisited and changed again
 - be positive: while the review's main purpose is to identify mistakes or bad
   patterns that are not caught by CI, reviews are also a good opportunity to
   give feedback on changes that are particularly good
@@ -98,23 +105,25 @@ which is why we follow a set of rules when doing so:
 
 ## Testing
 
-Testing is an integral part of our work and a necessity for delivering high
-quality results that also do not deteriorate over time. We generally do not
-merge untested changes and would usually not even review them as we cannot know
-whether the code under review actually works for all relevant scenarios.
+Testing is an integral part of all engineering work and a necessity for
+delivering high quality results that also do not deteriorate over time. Untested
+changes should generally not be merged and not even be reviewed as one cannot
+know whether the code under review actually works for all relevant scenarios. In
+fact, if there are no tests, it is likely the code will have to changes as tests
+are added and bugs are uncovered while doing so.
 
 While different languages and frameworks provide different testing mechanisms, a
 good approach generally is
 
-- leveraging small and isolated test cases (e.g. unit tests) for the majority of
-  the test cases including edge cases
-- leveraging higher level test cases (e.g. integration or acceptance tests) for
+- leveraging small and isolated tests (e.g. unit tests) for the majority of the
+  test cases including edge cases
+- leveraging higher level tests (e.g. integration or acceptance tests) for
   ensuring the main features and flows of an application work as expected
 
-We require continuous integration to be set up in all projects we work on. While
-it should always be possible to run tests locally, they also need to run
-automatically for every pull requests and after each merge to the project's main
-branch.
+Continuous integration must mandatorily be set up in order for a project to be
+successful. While it should always be possible to run tests locally, they also
+need to run automatically for every pull requests and after each merge to the
+project's main branch.
 
 ## Refactoring
 
@@ -125,13 +134,14 @@ code base does not become stale and improves productivity overall by keeping
 technical debt at a minimum and avoiding big, painful and risky rewrites that
 otherwise often become necessary down the line.
 
-When working on the code base, we will keep an eye open for parts that need to
-be refactored and either do so immediately in case of simple changes, or bring
-them up as individual issues for one of the next [iterations](../../process).
+When working on the code base, all engineers should keep an eye open for parts
+that need to be refactored and either do so immediately in case of simple
+changes, or bring them up as individual issues for one of the next
+[iterations](../../process).
 
 ## Pairing
 
 Pairing is a great way of spreading knowledge throughout the team, on-boarding
-new team members or resolving blockers. We encourage everyone to pair and will
-also pair with our clients' internal engineers to help them level up their
-experience.
+new team members or resolving blockers. We encourage project teams to make
+pairing an integral part of their daily workflow, even across focus areas with
+e.g. engineers and designers pairing when working on UI changes.


### PR DESCRIPTION
This changes the engineering workflow document so that it serves as a general recommendation rather than a description of what  **we** do.

The intro is left unchanged as that will be removed as part of #36 anyway.