### PR TITLE
generalize design workflow

### DIFF
--- a/workflow/design/README.md
+++ b/workflow/design/README.md
@@ -6,22 +6,25 @@ designing applications.
 
 ## Design Sources
 
-We manage design source files like code, maintaining an authoritative main line
-and making changes in change sets that are only applied back to the mainline
-once complete. Design sources can be maintained using a version control system
-just like for the project's code or in a separate system, depending on the
-environment of a project.
+Design source files should generally be managed like code, maintaining an
+authoritative main line and making changes in change sets that are only applied
+back to the mainline once complete and reviewed. Design sources can be
+maintained using a version control system just like for the project's source
+code or in a separate system, depending on the available tools and
+infrastructure.
 
 ### Change Sets/Branches
 
-No changes to design sources are ever applied directly to the mainline. Only
-after a set of changes has been reviewed and deemed good for application is it
-applied back as one discrete change. All individual changes that are applied
-back together should be related to the same UI element(s). Once changes have
-been applied back to the mainline, that fact should be noted in the issue
-describing the work that was done in the change. The change should also be
-referenced in the issue if the tools allow that or if that is not the case, a
-static image of the change should be attached to the issue.
+Just like changes to a project's source code, no changes to design sources
+should ever be applied directly to the mainline. Only after a set of changes has
+been reviewed and deemed good is it applied back as one discrete change. All
+individual changes that are applied back together should be related to the same
+UI element(s) or aspect of the UI (e.g. changing the color scheme once for all
+UI elements). Once changes have been applied back to the mainline, that fact
+should be noted in the issue describing the work that was done in the change.
+The change should also be referenced in the issue if the tools allow that or if
+that is not the case, before/after images of the change should be attached to
+the issue.
 
 #### Reviews
 


### PR DESCRIPTION
This changes the design workflow document so that it serves as a general recommendation rather than a description of what **we** do.

The intro is left unchanged as that will be removed as part of #36 anyway.