### PR TITLE
rename process to development process

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ The [Project Flow document](./project-flow) describes how we approach new
 projects and work with clients. We target a smooth start with minimal overhead
 and encourage our clients to take on an active role.
 
-## [Process](./process)
+## [Development Process](./development-process)
 
-The [Process document](./process) describes how we prepare and run iterations
-(referred to as _"sprints"_ elsewhere but we think that term implies practices
-we want to avoid and therefore don't use it). We make sure all project
-stakeholders get heard and contribute to an iteration and every task is well
-understood, clearly scoped and assessed for hidden risk before it gets planned.
+The [Development Process document](./development-process) describes how we
+prepare and run iterations (referred to as _"sprints"_ elsewhere but we think
+that term implies practices we want to avoid and therefore don't use it). We
+make sure all project stakeholders get heard and contribute to an iteration and
+every task is well understood, clearly scoped and assessed for hidden risk
+before it gets planned.
 
 ## [Workflow](./workflow)
 

--- a/development-process/README.md
+++ b/development-process/README.md
@@ -1,13 +1,13 @@
-# Process
+# Development Process
 
-An effective process supports the team rather than stand in its way. It does not
-introduce a set of formalities only for the sake of it and favors enablement and
-communication over top-down management. A good process also ensures the right
-tasks are being worked on at the right time (and in a proper way) and provides a
-reasonable level of short term predictability. At the same time it remains
-flexible enough to adapt to unexpected events.
+An effective development process supports the team rather than stand in its way.
+It does not introduce a set of formalities only for the sake of it and favors
+enablement and communication over top-down management. A good process also
+ensures the right tasks are being worked on at the right time (and in a proper
+way) and provides a reasonable level of short term predictability. At the same
+time it remains flexible enough to adapt to unexpected events.
 
-The simplabs process has a few key characteristics and goals:
+The simplabs development process has a few key characteristics and goals:
 
 - It ensures all project stakeholders get heard and no single party dictates a
   project's priorities.
@@ -22,11 +22,11 @@ The simplabs process has a few key characteristics and goals:
 
 ## Iterations
 
-Our process is based on _"iterations"_ in which a clearly defined set of tasks
-is being worked on and ideally completed during the iteration. Iterations are
-similar to what's often referred to as sprint but we refrain from that
-terminology for its negative connotations - after all, the goal is not to rush
-work out but to build a project incrementally and iteratively. The concrete
+Our development process is based on _"iterations"_ in which a clearly defined
+set of tasks is being worked on and ideally completed during the iteration.
+Iterations are similar to what's often referred to as sprint but we refrain from
+that terminology for its negative connotations - after all, the goal is not to
+rush work out but to build a project incrementally and iteratively. The concrete
 tasks for an iteration are identified, defined and prepared collaboratively with
 all project stakeholders before the iteration starts. We do not recommend
 maintaining a backlog with tasks for all of the work that needs to happen for a
@@ -47,11 +47,12 @@ that was planned.
 
 ### Roles
 
-Our process works with flat project teams without dedicated project managers.
-For any given iteration, one of the team members (a designer or engineer) will
-take on the role of _"Iteration Lead"_ who is responsible for planning the
-iteration and ensuring smooth execution. This is a rotating role so that every
-member of the team will assume it every once in a while (unless they opt out).
+Our development process works with flat project teams without dedicated project
+managers. For any given iteration, one of the team members (a designer or
+engineer) will take on the role of _"Iteration Lead"_ who is responsible for
+planning the iteration and ensuring smooth execution. This is a rotating role so
+that every member of the team will assume it every once in a while (unless they
+opt out).
 
 Making the iteration lead a rotating role ensures that all team members hear the
 perspectives of all project stakeholders and do not get stuck in only
@@ -113,11 +114,11 @@ besides contributing to the current iteration.
 
 #### Issues
 
-Well-prepared issues are a key element of an effective process. They provide
-guidance for the project team's work, allow external parties not involved with
-the project directly to get an understanding of what is happening, and can serve
-as future reference to understand what was done in a project, and for which
-reasons.
+Well-prepared issues are a key element of an effective development process. They
+provide guidance for the project team's work, allow external parties not
+involved with the project directly to get an understanding of what is happening,
+and can serve as future reference to understand what was done in a project, and
+for which reasons.
 
 Good issues aim to:
 

--- a/project-flow/consulting/README.md
+++ b/project-flow/consulting/README.md
@@ -24,8 +24,8 @@ systems. In order to be most effective in that new environment, they must know
 and understand its constituent parts. Therefore we ask clients to introduce our
 consultants to:
 
-- their in-house team structure and engineering process (for clients lacking an
-  effective process, we can introduce [ours](./../../process))
+- their in-house team structure and development process (for clients lacking an
+  effective process, we can introduce [ours](./../../development-process))
 - their engineering infrastructure, covering tools like version control systems,
   issue trackers, Continuous Integration and Continuous Deployment setups, VPNs
   etc.

--- a/project-flow/full-service/README.md
+++ b/project-flow/full-service/README.md
@@ -1,7 +1,6 @@
 # Full Service Project Flow
 
-Developing Digital Products is a process that can be broken down into four main
-stages:
+Developing Digital Products can be broken down into four main stages:
 
 - identifying and understanding the goal of the project
 - conceptualising a product that pursues that objective
@@ -207,10 +206,11 @@ anyway.
 In the execution phase of an increment, user stories are turned into usable
 features of the product, iteratively building it up over time. Each user story
 should be broken down into fine-grained and more detailed issues and worked on
-following a smooth [process](../process/). As that is done, engineers and
-designers continue to work closely with the business experts, discussing
-individual facets of user stories as well as different alternatives for
-designing and implementing those along with the associated effort.
+following a smooth [development process](../development-process/). As that is
+done, engineers and designers continue to work closely with the business
+experts, discussing individual facets of user stories as well as different
+alternatives for designing and implementing those along with the associated
+effort.
 
 The project team will build slices of the system at once, including everything
 from the design, backend, and frontend code of a particular user story so those

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -19,17 +19,17 @@ those), the latter team member will self-assign the issue once the former is
 done with their work.
 
 Although issues should be well-understood and well-prepared before they are even
-planned for a particular [iteration](../../process), for more complex issues it
-is often beneficial to prepare them further before starting implementation. For
-these kinds of issues, the first step is to break them down into smaller,
-concrete steps (which is often a great thing to do in a
+planned for a particular [iteration](../../development-process), for more
+complex issues it is often beneficial to prepare them further before starting
+implementation. For these kinds of issues, the first step is to break them down
+into smaller, concrete steps (which is often a great thing to do in a
 [pairing session](./engineering/#pairing)).
 
 Once an issue is resolved via a [pull request](./engineering/#feature-branches)
 or if it is blocked, the engineer(s) will self-assign another issue from the
 iteration backlog. If an issue is blocked and cannot progress, the engineers
-working on it contact the [iteration lead](../../process) who - in collaboration
-with whomever necessary - tries to resolve the impediment.
+working on it contact the [iteration lead](../../development-process) who - in
+collaboration with whomever necessary - tries to resolve the impediment.
 
 All discussions around an issue should happen on the particular issue's page. Of
 course at times it is convenient to have discussions in person or over online

--- a/workflow/engineering/README.md
+++ b/workflow/engineering/README.md
@@ -68,8 +68,8 @@ requests from being merged.
 ### Preview Systems
 
 In addition to setting up
-[continuous deployment](../../process/#iteration-execution) for deploying all
-changes that get merged into a project's main branch to production
+[continuous deployment](../../development-process/#iteration-execution) for
+deploying all changes that get merged into a project's main branch to production
 automatically, we recommend creating a mechanism that allows booting
 per-branch/pull request staging systems on demand which we call preview systems.
 These systems would ideally be automatically created (and destroyed once the
@@ -173,7 +173,7 @@ otherwise often become necessary down the line.
 When working on the code base, all engineers should keep an eye open for parts
 that need to be refactored and either do so immediately in case of simple
 changes, or bring them up as individual issues for one of the next
-[iterations](../../process).
+[iterations](../../development-process).
 
 ## Pairing
 


### PR DESCRIPTION
This renames the _"Process"_ to _"Development Process"_ so it is clearer that it applies to the development phase of a project.

closes #52 