### PR TITLE
add section on project setup

### DIFF
--- a/project-procedure/digital-products/README.md
+++ b/project-procedure/digital-products/README.md
@@ -28,7 +28,7 @@ among the stakeholders. The main tasks are:
   assets; we recommend using a system that allows maintaining assets like source
   code with branching, pull request and review mechanisms
 - deciding and setting up a system for maintaining and collaborating on
-  documents (e.g. user stories etc.); this system should support versioning and
+  documents (e.g. user stories, etc.); this system should support versioning and
   commenting for effective collaboration
 - setting up a shared communication channel that fosters traceable group
   communication; while the particular tool of choice is not relevant, we advice


### PR DESCRIPTION
This adds a section on how to set up a project properly before any of the work is started to the digital products guide. The section talks about setting up VCS, a similar system for design assets, something like google docs and slack and ensuring everyone has access and will receive relevant notifications.

closes #59 